### PR TITLE
Small fixes

### DIFF
--- a/Python/Lib/typeWorldClient/__init__.py
+++ b/Python/Lib/typeWorldClient/__init__.py
@@ -90,7 +90,7 @@ def addJSONSubscription(url):
 		return responses, None
 
 
-	if url.split('://')[1].count(':') > 1:
+	if url.split('://')[1].count(':') > 2:
 		responses['errors'].append('URL contains more than one : sign, so don’t know how to parse it.')
 		return responses, None
 

--- a/Python/Lib/typeWorldClient/__init__.py
+++ b/Python/Lib/typeWorldClient/__init__.py
@@ -557,7 +557,11 @@ class APIPublisher(object):
 		# Register endpoint
 		url = 'https://type.world/registerAPIEndpoint/?url=%s' % urllib.parse.quote(self.canonicalURL)
 		request = urllib.request.Request(url)
-		response = urllib.request.urlopen(request, cafile=certifi.where())
+		try:
+			response = urllib.request.urlopen(request, cafile=certifi.where())
+		except urllib.error.HTTPError as e:
+			print('API endpoint alive HTTP error: %s' % e)
+			return
 		response = json.loads(response.read())
 
 		if response['success'] == True:

--- a/Python/Lib/typeWorldClient/__init__.py
+++ b/Python/Lib/typeWorldClient/__init__.py
@@ -91,7 +91,7 @@ def addJSONSubscription(url):
 
 
 	if url.split('://')[1].count(':') > 2:
-		responses['errors'].append('URL contains more than one : sign, so don’t know how to parse it.')
+		responses['errors'].append('URL contains more than two : signs, so don’t know how to parse it.')
 		return responses, None
 
 	customProtocol, transportProtocol, subscriptionID, secretKey, restDomain = splitJSONURL(url)


### PR DESCRIPTION
* Catch URLLib urlopen errors in `stillAlive()`
* Allow second ":" in URL (e.g. host with port)